### PR TITLE
allow statements; pass through syntax errors to repl module

### DIFF
--- a/src/evaler/evaler.js
+++ b/src/evaler/evaler.js
@@ -45,12 +45,7 @@ module.exports = function Evaler (options, console)
 		}
 		catch (e)
 		{
-			/* don't know what actually I did */
-			if (code !== '.scope')
-			{
-				console.error(e);
-			}
-			return callback();
+			return callback(e);
 		}
 
 		new Promise(function (rs, rj)


### PR DESCRIPTION
Mostly for node 0.10 compat, but this also allows multiline statements. Generally, just let repl handle the errors emitted during script parsing.

https://github.com/nodejs/node/blob/v0.10.40-release/lib/repl.js#L239
